### PR TITLE
dl_error -> dlerror

### DIFF
--- a/ice_function.h
+++ b/ice_function.h
@@ -52,7 +52,7 @@ public:
 			{
 				std::stringstream err;
 				err << "Failed to Retrieve address of function '" << name <<
-					"': " << dl_error();
+					"': " << dlerror();
 				throw ice::Exception(err.str());
 			}
 		#endif


### PR DESCRIPTION
I've tested ice-- on Ubuntu. The only change required to make it work is to use "dlerror()" instead of "dl_error()". The dl_error does not exist and causes compiler error (GCC 4.8.1).
